### PR TITLE
Add test extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Install PyTokenCounter using `pip`:
 pip install PyTokenCounter
 ```
 
+To run the project's test suite, install the optional test dependencies:
+
+```bash
+pip install "PyTokenCounter[test]"
+```
+
 ## Usage
 
 Here are a few examples to get you started with PyTokenCounter, especially in the context of **LLMs**:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 exclude = ["Tests"]
+
+[project.optional-dependencies.test]
+numpy = "*"
+Pillow = "*"


### PR DESCRIPTION
## Summary
- declare optional test dependencies numpy and Pillow
- document how to install test extras

## Testing
- `python Tests/Runner.py` *(fails: ModuleNotFoundError: No module named 'numpy')*